### PR TITLE
Add PDF summarization chain

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,7 @@
+from typing import List
+from langchain_core.documents import Document
+
+
+def format_docs(docs: List[Document]) -> str:
+    """Join document contents into a single string."""
+    return "\n\n".join(doc.page_content for doc in docs)

--- a/langchain_service/chain/pdf_chain.py
+++ b/langchain_service/chain/pdf_chain.py
@@ -1,0 +1,58 @@
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_community.document_loaders import PyMuPDFLoader
+from langchain_community.vectorstores import FAISS
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables import RunnablePassthrough
+from langchain_core.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from dotenv import load_dotenv
+import numpy as np
+import faiss
+
+from app.utils import format_docs
+
+load_dotenv(override=True)
+
+
+def summarize_last_page(file_path: str, question: str = "마지막 페이지 요약해줘") -> str:
+    """Load a PDF file and answer a question about its content."""
+    loader = PyMuPDFLoader(file_path)
+    docs = loader.load()
+
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=50)
+    split_documents = text_splitter.split_documents(docs)
+
+    embeddings = OpenAIEmbeddings()
+    vectorstore = FAISS.from_documents(documents=split_documents, embedding=embeddings)
+
+    _ = vectorstore.index.reconstruct(0)
+    n_vectors = vectorstore.index.ntotal
+    _ = np.array([vectorstore.index.reconstruct(i) for i in range(n_vectors)])
+
+    retriever = vectorstore.as_retriever()
+
+    prompt = PromptTemplate.from_template(
+        """You are an assistant for question-answering tasks.
+Use the following pieces of retrieved context to answer the question.
+If you don't know the answer, just say that you don't know.
+Answer in Korean.
+
+#Question:
+{question}
+#Context:
+{context}
+
+#Answer:"""
+    )
+
+    llm = ChatOpenAI(model_name="gpt-4o", temperature=0)
+
+    chain = (
+        {"context": retriever | format_docs, "question": RunnablePassthrough()}
+        | prompt
+        | llm
+        | StrOutputParser()
+    )
+
+    response = chain.invoke(question)
+    return response


### PR DESCRIPTION
## Summary
- Add PDF summarization chain using LangChain, FAISS, and OpenAI
- Provide utility to format retrieved documents

## Testing
- `python -m py_compile app/utils.py langchain_service/chain/pdf_chain.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c16a7d1e888328bdaf251dfa75c808