### PR TITLE
fix: pdfRAG 엔드포인트 파일 저장 구현

### DIFF
--- a/api/endpoints/msp_service.py
+++ b/api/endpoints/msp_service.py
@@ -58,14 +58,29 @@ async def uploadRAG(request: Request, file: UploadFile = File(...)):
 
 
 @service_router.post("/pdfRAG")
-async def pdf_rag(question: str = Form(...), file: UploadFile = File(...)):
+async def pdf_rag(
+    question: str = Form(...),
+    file: UploadFile = File(...),
+    upload_dir: str = Form(None, alias="UPLOADED_FILES"),
+):
     contents = await file.read()
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+
+    # 지정된 폴더가 있다면 해당 경로에 파일을 저장하고, 없다면 임시파일을 사용한다.
+    if upload_dir:
+        os.makedirs(upload_dir, exist_ok=True)
+        file_path = os.path.join(upload_dir, file.filename)
+        with open(file_path, "wb") as f:
+            f.write(contents)
+        remove_after = False
+    else:
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
         tmp.write(contents)
-        tmp_path = tmp.name
+        tmp.close()
+        file_path = tmp.name
+        remove_after = True
 
     try:
-        documents = load_document(tmp_path)
+        documents = load_document(file_path)
         splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
         docs = splitter.split_documents(documents)
         embeddings = OpenAIEmbeddings(api_key=GPT_API)
@@ -75,7 +90,8 @@ async def pdf_rag(question: str = Form(...), file: UploadFile = File(...)):
         qa = RetrievalQA.from_chain_type(llm=llm, retriever=retriever)
         answer = qa.run(question)
     finally:
-        os.remove(tmp_path)
+        if remove_after and os.path.exists(file_path):
+            os.remove(file_path)
 
     return {"answer": answer}
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,7 @@
+from typing import List
+from langchain_core.documents import Document
+
+
+def format_docs(docs: List[Document]) -> str:
+    """Join document contents into a single string."""
+    return "\n\n".join(doc.page_content for doc in docs)

--- a/file/index.html
+++ b/file/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>PDF RAG 테스트</title>
+</head>
+<body>
+    <h1>PDF RAG 테스트</h1>
+    <input type="file" id="pdfFile" accept="application/pdf" />
+    <input type="text" id="question" placeholder="질문을 입력하세요" />
+    <button id="send">질문하기</button>
+    <pre id="result"></pre>
+
+    <script>
+    document.getElementById('send').addEventListener('click', async () => {
+        const fileInput = document.getElementById('pdfFile');
+        const question = document.getElementById('question').value;
+        if (!fileInput.files.length) {
+            alert('PDF 파일을 선택하세요');
+            return;
+        }
+        const formData = new FormData();
+        formData.append('file', fileInput.files[0]);
+        formData.append('question', question);
+
+        const response = await fetch('/MSP_SERVICE/pdfRAG', {
+            method: 'POST',
+            body: formData
+        });
+        const data = await response.json();
+        document.getElementById('result').textContent = data.answer || JSON.stringify(data);
+    });
+    </script>
+</body>
+</html>

--- a/file/index.html
+++ b/file/index.html
@@ -12,6 +12,7 @@
     <pre id="result"></pre>
 
     <script>
+    const UPLOADED_FILES = "C:\Users\leegy\Desktop\2025\back\saved_file";
     document.getElementById('send').addEventListener('click', async () => {
         const fileInput = document.getElementById('pdfFile');
         const question = document.getElementById('question').value;
@@ -22,6 +23,7 @@
         const formData = new FormData();
         formData.append('file', fileInput.files[0]);
         formData.append('question', question);
+        formData.append('UPLOADED_FILES', UPLOADED_FILES);
 
         const response = await fetch('/MSP_SERVICE/pdfRAG', {
             method: 'POST',

--- a/langchain_service/chain/pdf_chain.py
+++ b/langchain_service/chain/pdf_chain.py
@@ -1,0 +1,58 @@
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_community.document_loaders import PyMuPDFLoader
+from langchain_community.vectorstores import FAISS
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables import RunnablePassthrough
+from langchain_core.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from dotenv import load_dotenv
+import numpy as np
+import faiss
+
+from app.utils import format_docs
+
+load_dotenv(override=True)
+
+
+def summarize_last_page(file_path: str, question: str = "마지막 페이지 요약해줘") -> str:
+    """Load a PDF file and answer a question about its content."""
+    loader = PyMuPDFLoader(file_path)
+    docs = loader.load()
+
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=50)
+    split_documents = text_splitter.split_documents(docs)
+
+    embeddings = OpenAIEmbeddings()
+    vectorstore = FAISS.from_documents(documents=split_documents, embedding=embeddings)
+
+    _ = vectorstore.index.reconstruct(0)
+    n_vectors = vectorstore.index.ntotal
+    _ = np.array([vectorstore.index.reconstruct(i) for i in range(n_vectors)])
+
+    retriever = vectorstore.as_retriever()
+
+    prompt = PromptTemplate.from_template(
+        """You are an assistant for question-answering tasks.
+Use the following pieces of retrieved context to answer the question.
+If you don't know the answer, just say that you don't know.
+Answer in Korean.
+
+#Question:
+{question}
+#Context:
+{context}
+
+#Answer:"""
+    )
+
+    llm = ChatOpenAI(model_name="gpt-4o", temperature=0)
+
+    chain = (
+        {"context": retriever | format_docs, "question": RunnablePassthrough()}
+        | prompt
+        | llm
+        | StrOutputParser()
+    )
+
+    response = chain.invoke(question)
+    return response


### PR DESCRIPTION
## Summary
- pdfRAG 라우터가 전달받은 경로에 업로드 파일을 저장하도록 수정
- 경로가 없으면 임시 파일을 사용해 처리 후 삭제

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c17469a1a48328923d465bbbd55ba4